### PR TITLE
iccv release bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ conda install pytorch==1.12.1 torchvision==0.13.1 torchaudio==0.12.1 -c pytorch
 3. Install additional packages with: `pip install -r requirements.txt`
 
 ## Downloading Required Datasets and Checkpoints
-Download required datasets and checkpoints [here](https://drive.google.com/file/d/1qHMyqR1GEGqRcLorB1YQfF-ALCyUmp1f/view?usp=drive_link). After downloading, extract the zip file and place the subfolders in `data/`
+Download required datasets and checkpoints [here](https://drive.google.com/file/d/1AI2ZBOBUD6M860UpxfmQ8nMAGVCTuMdt/view?usp=sharing). After downloading, extract the zip file and place the subfolders in `data/`
 
 ## Pre-trained Image Classification Models
 Checkpoints for pre-trained image classification models are provided [here](). Download and extract the zip file. Place the subfolders in the `ckpts/` folder.

--- a/postprocess/02_compile_explanations.py
+++ b/postprocess/02_compile_explanations.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
     start_idx = 0
     summarized_results = []
     for saliency_method in SALIENCY_METHODS:
-        if saliency_method in ["lime", "blur_ig", "smoothgrad"]:
+        if saliency_method in ["lime", "blur_ig", "smoothgrad", "guided_ig"]:
             end_idx = 50
         else:
             end_idx = 500

--- a/src/utils/transforms.py
+++ b/src/utils/transforms.py
@@ -39,7 +39,8 @@ def get_reverse_affine_explanations(rotated_explanation, rotated_ones_mask, rot_
 def get_similarity(explanation, t_explanation, method="ssim", mask=None):
     if method == "ssim":
         # Window size to 5 following "Sanity Checks for Saliency Maps"
-        ssim_val, ssim_full = ssim(explanation, t_explanation, win_size=5, full=True)
+        drange = max(t_explanation.max() - t_explanation.min(), explanation.max() - explanation.min())
+        ssim_val, ssim_full = ssim(explanation, t_explanation, win_size=5, full=True, data_range=drange)
         if mask is not None:
             # Erode the mask to only use areas which have no invalid pixels
             mask = binary_erosion(mask, footprint=np.ones((5, 5)))


### PR DESCRIPTION
Bugfix in `src/utils/transforms.py`, without this change I get the error message:
`ValueError: Since image dtype is floating point, you must specify the data_range parameter. Please read the documentation carefully (including the note). It is recommended that you always specify the data_range anyway.`

Bugfix in `postprocess/02_compile_explanations.py`, guided_ig also ran on 50 samples.

Fixes #2. 